### PR TITLE
Fix Github actions

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -8,15 +8,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint
-        run: docker-compose -f ./docker-compose-ci.yml run lint-tests
+        run: docker compose -f ./docker-compose-ci.yml run lint-tests
 
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Unit and e2e tests
         env:
           WEB3_PROVIDER_URL: ${{ secrets.WEB3_PROVIDER_URL }}
-        run: docker-compose -f ./docker-compose-ci.yml run tests
+        run: docker compose -f ./docker-compose-ci.yml run tests

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -12,16 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Lint
-        run: docker-compose -f ./docker-compose-ci.yml run lint-tests
+        run: docker compose -f ./docker-compose-ci.yml run lint-tests
 
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Unit and e2e tests
         env:
           WEB3_PROVIDER_URL: ${{ secrets.WEB3_PROVIDER_URL }}
-        run: docker-compose -f ./docker-compose-ci.yml run tests
+        run: docker compose -f ./docker-compose-ci.yml run tests
 
   publish:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
       - lint
       - tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v1.16
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -8,21 +8,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
 
       - name: Lint
-        run: docker-compose -f ./docker-compose-ci.yml run lint-tests
+        run: docker compose -f ./docker-compose-ci.yml run lint-tests
 
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
 
       - name: Unit and e2e tests
         env:
           WEB3_PROVIDER_URL: ${{ secrets.WEB3_PROVIDER_URL }}
-        run: docker-compose -f ./docker-compose-ci.yml run tests
+        run: docker compose -f ./docker-compose-ci.yml run tests

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,7 +11,7 @@ jobs:
   check-secret-leakage:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
           go-version: "1.19"


### PR DESCRIPTION
1. `docker-compose` has been deprecated, and we need to use `docker compose` now
2. Bump checkout version to v4