### PR TITLE
Add solapp domain names to CORS allowlist

### DIFF
--- a/huma_utils/constants.py
+++ b/huma_utils/constants.py
@@ -12,6 +12,8 @@ SERVER_ALLOW_ORIGIN_REGEX = (
     r"|https://testnet\.campaign-points\.huma\.finance"
     r"|https://dev\.mainnet\.campaign-points\.huma\.finance"
     r"|https://testnet\.campaign-points\.huma\.finance"
+    r"|https://devnet\.solapp\.huma\.finance"
+    r"|https://dev\.devnet\.solapp\.huma\.finance"
     r"|https://local\.bulla\.network:1234"
     r"|https://dev\.bulla\.network"
     r"|https://banker\.bulla\.network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "huma-utils"
-version = "0.13.1"
+version = "0.13.2"
 description = "Huma Python utilities library"
 authors = ["Flora Huang <flora@huma.finance>", "Jiatu Liu <jiatu@huma.finance>"]
 readme = "README.md"


### PR DESCRIPTION
The two domain names are still in use.